### PR TITLE
Custom status text

### DIFF
--- a/simple-rest-client/index.html
+++ b/simple-rest-client/index.html
@@ -74,6 +74,7 @@
               <pre><code name="codeData" id="codeData" class="chili-lang-html">&nbsp;</code></pre>
             </div>
           </div>
+          <div id="respText"></div>
         </div>
       </fieldset>
     </section>

--- a/simple-rest-client/requester.js
+++ b/simple-rest-client/requester.js
@@ -125,7 +125,7 @@ function readResponse() {
       var content_type = this.getResponseHeader('Content-Type');
       var content_length = this.getResponseHeader('Content-Length');
       console.log(content_length);
-      $("#responseStatus").html(this.status+' '+statusCodes[this.status]);
+      $("#responseStatus").html(this.status+' '+(this.statusText || statusCodes[this.status]));
       $("#responseHeaders").val(jQuery.trim(this.getAllResponseHeaders()));
       var debugurl = /X-Debug-URL: (.*)/i.exec($("#responseHeaders").val());
       if (debugurl) {


### PR DESCRIPTION
Hello,
Sometimes an HTTP service responds with custom status text corresponding to a status code, for instance, instead of "Bad Request" for a 400 response, the service might return "Missing parameter foo_id".  I've made one commit that will output the XMLHTTPRequest.statusText if it is available.  Failing that, it will output the text that is defined in requester.js.

-Elijah
